### PR TITLE
Removed boot completed as provider is implicitly started via FPS on r…

### DIFF
--- a/DeveloperConfigProvider/src/main/AndroidManifest.xml
+++ b/DeveloperConfigProvider/src/main/AndroidManifest.xml
@@ -73,7 +73,6 @@
 
         <receiver android:name="com.aevi.sdk.pos.flow.config.StartUpReceiver">
             <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED"/>
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
             </intent-filter>
         </receiver>


### PR DESCRIPTION
…estart